### PR TITLE
add ability to use multiple search providers at once

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,7 @@ export interface SearchResult {
   /** When the result was published or last updated */
   publishedDate?: string;
   /** The search provider that returned this result */
-  provider?: string;
+  provider: string;
   /** Raw response data from the provider */
   raw?: unknown;
 }
@@ -90,6 +90,6 @@ export interface ProviderConfig {
  * Options for the main webSearch function
  */
 export interface WebSearchOptions extends SearchOptions {
-  /** Search provider to use */
-  provider: SearchProvider;
+  /** Array of search providers to query in parallel */
+  provider: SearchProvider[];
 }


### PR DESCRIPTION
this pr adds the ability to provide an array of providers to the provider param of webSearch options. under the hood it creates promises for each provider interface that are executed in parallel. this implementation fails slow, where it will only throw an error if all providers fail